### PR TITLE
Single degrees (first pass) and ACF field updates

### DIFF
--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -991,5 +991,87 @@
         "hide_on_screen": "",
         "active": 1,
         "description": ""
+    },
+    {
+        "key": "group_595fd2b9efda6",
+        "title": "Post Fields",
+        "fields": [
+            {
+                "key": "field_595fd2c3f4891",
+                "label": "Associated People",
+                "name": "post_associated_people",
+                "type": "relationship",
+                "instructions": "Select one or more existing people that this article is related to.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "person"
+                ],
+                "taxonomy": [
+                    
+                ],
+                "filters": [
+                    "search",
+                    "taxonomy"
+                ],
+                "elements": [
+                    "featured_image"
+                ],
+                "min": "",
+                "max": "",
+                "return_format": "id"
+            },
+            {
+                "key": "field_595ff05fbb5a5",
+                "label": "test",
+                "name": "test",
+                "type": "relationship",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    
+                ],
+                "taxonomy": [
+                    
+                ],
+                "filters": [
+                    "search",
+                    "post_type",
+                    "taxonomy"
+                ],
+                "elements": "",
+                "min": "",
+                "max": "",
+                "return_format": "object"
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "post"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
     }
 ]

--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -1025,35 +1025,6 @@
                 "min": "",
                 "max": "",
                 "return_format": "id"
-            },
-            {
-                "key": "field_595ff05fbb5a5",
-                "label": "test",
-                "name": "test",
-                "type": "relationship",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "post_type": [
-                    
-                ],
-                "taxonomy": [
-                    
-                ],
-                "filters": [
-                    "search",
-                    "post_type",
-                    "taxonomy"
-                ],
-                "elements": "",
-                "min": "",
-                "max": "",
-                "return_format": "object"
             }
         ],
         "location": [

--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -624,7 +624,7 @@
             {
                 "key": "field_5953aa7625c15",
                 "label": "Phone Numbers",
-                "name": "person_phones",
+                "name": "person_phone_numbers",
                 "type": "repeater",
                 "instructions": "One or more phone numbers at which the person can be contacted.",
                 "required": 0,

--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -901,7 +901,7 @@
             {
                 "key": "field_5953ca9f7345b",
                 "label": "Video and Media",
-                "name": "person_media",
+                "name": "person_medias",
                 "type": "repeater",
                 "instructions": "",
                 "required": 0,

--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -1,5 +1,52 @@
 [
     {
+        "key": "group_596773ca3713a",
+        "title": "Degree Fields - Default Template",
+        "fields": [
+            {
+                "key": "field_596773d77642a",
+                "label": "Custom Sidebar Content",
+                "name": "degree_sidebar_content",
+                "type": "wysiwyg",
+                "instructions": "Custom content to display in the degree template sidebar.  Is displayed underneath the degree's call-to-action buttons on desktop and tablet screen sizes, and beneath the degree description on mobile screen sizes.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "degree"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "default"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
+    },
+    {
         "key": "group_58f7a73f5fecc",
         "title": "Header Media Fields",
         "fields": [
@@ -38,7 +85,7 @@
                     "header-media-fullscreen": "Fullscreen"
                 },
                 "default_value": [
-                    
+
                 ],
                 "allow_null": 1,
                 "multiple": 0,
@@ -389,67 +436,6 @@
                     "param": "page_type",
                     "operator": "==",
                     "value": "front_page"
-                }
-            ]
-        ],
-        "menu_order": 0,
-        "position": "normal",
-        "style": "default",
-        "label_placement": "top",
-        "instruction_placement": "label",
-        "hide_on_screen": "",
-        "active": 1,
-        "description": ""
-    },
-    {
-        "key": "group_593afe53a4a76",
-        "title": "News Article",
-        "fields": [
-            {
-                "key": "field_593afe5cbed57",
-                "label": "News Lead Paragraph",
-                "name": "news_lead_paragraph",
-                "type": "textarea",
-                "instructions": "Lead paragraph displayed below the title on a news article.",
-                "required": 1,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "",
-                "maxlength": "",
-                "rows": "",
-                "new_lines": "wpautop"
-            },
-            {
-                "key": "field_593b025ebb1ce",
-                "label": "News Byline",
-                "name": "news_byline",
-                "type": "text",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "John Doe",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            }
-        ],
-        "location": [
-            [
-                {
-                    "param": "post_type",
-                    "operator": "==",
-                    "value": "publication"
                 }
             ]
         ],
@@ -1013,7 +999,7 @@
                     "person"
                 ],
                 "taxonomy": [
-                    
+
                 ],
                 "filters": [
                     "search",

--- a/functions.php
+++ b/functions.php
@@ -6,6 +6,7 @@ include_once 'includes/wp-bs-navwalker.php';
 
 include_once 'includes/header-functions.php';
 include_once 'includes/person-functions.php';
+include_once 'includes/degree-functions.php';
 
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -142,8 +142,8 @@ function get_media_background_video( $videos, $loop=false ) {
 		<?php endif; ?>
 	</video>
 	<button class="media-background-video-toggle btn play-enabled hidden-xs-up" type="button" data-toggle="button" aria-pressed="false" aria-label="Play or pause background videos">
-		<span class="fa fa-pause media-background-video-pause"></span>
-		<span class="fa fa-play media-background-video-play"></span>
+		<span class="fa fa-pause media-background-video-pause" aria-hidden="true"></span>
+		<span class="fa fa-play media-background-video-play" aria-hidden="true"></span>
 	</button>
 <?php
 	return ob_get_clean();

--- a/includes/config.php
+++ b/includes/config.php
@@ -87,6 +87,15 @@ function define_customizer_sections( $wp_customize ) {
 			)
 		);
 	}
+
+	if ( post_type_exists( 'degree' ) ) {
+		$wp_customize->add_section(
+			THEME_CUSTOMIZER_PREFIX . 'degrees',
+			array(
+				'title' => 'Degrees'
+			)
+		);
+	}
 }
 
 add_action( 'customize_register', 'define_customizer_sections' );
@@ -240,6 +249,45 @@ function define_customizer_fields( $wp_customize ) {
 					'label'       => 'Default Header Image (-xs)',
 					'description' => 'Default header image at the -xs breakpoint for single person templates. Recommended dimensions: 575px x 575px',
 					'section'     => THEME_CUSTOMIZER_PREFIX . 'people',
+					'mime_type'   => 'image'
+				)
+			)
+		);
+
+	}
+
+	// Degrees
+	if ( post_type_exists( 'degree' ) ) {
+
+		$wp_customize->add_setting(
+			'degree_header_image'
+		);
+
+		$wp_customize->add_control(
+			new WP_Customize_Media_Control(
+				$wp_customize,
+				'degree_header_image',
+				array(
+					'label'       => 'Default Header Image (-sm+)',
+					'description' => 'Default header image at the -sm breakpoint and up for single degree templates. Recommended dimensions: 1600px x 400px',
+					'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees',
+					'mime_type'   => 'image'
+				)
+			)
+		);
+
+		$wp_customize->add_setting(
+			'degree_header_image_xs'
+		);
+
+		$wp_customize->add_control(
+			new WP_Customize_Media_Control(
+				$wp_customize,
+				'degree_header_image_xs',
+				array(
+					'label'       => 'Default Header Image (-xs)',
+					'description' => 'Default header image at the -xs breakpoint for single degree templates. Recommended dimensions: 575px x 575px',
+					'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees',
 					'mime_type'   => 'image'
 				)
 			)

--- a/includes/config.php
+++ b/includes/config.php
@@ -10,9 +10,11 @@ define( 'THEME_JS_URL', THEME_STATIC_URL . '/js' );
 define( 'THEME_IMG_URL', THEME_STATIC_URL . '/img' );
 define( 'THEME_CUSTOMIZER_PREFIX', 'ucf_colleges_' );
 define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
-	'person_header_title' => 'Faculty and Research',
-	'person_header_subtitle' => get_bloginfo( 'name' ),
-	'person_thumbnail' => THEME_IMG_URL . '/no-photo.jpg'
+	'apply_undergraduate_url' => 'https://apply.ucf.edu/application/',
+	'apply_graduate_url'      => 'https://application.graduate.ucf.edu/',
+	'person_header_title'     => 'Faculty and Research',
+	'person_header_subtitle'  => get_bloginfo( 'name' ),
+	'person_thumbnail'        => THEME_IMG_URL . '/no-photo.jpg'
 ) ) );
 
 
@@ -76,6 +78,13 @@ function define_customizer_sections( $wp_customize ) {
 		THEME_CUSTOMIZER_PREFIX . 'webfonts',
 		array(
 			'title' => 'Web Fonts'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'admissions',
+		array(
+			'title' => 'UCF Admissions'
 		)
 	);
 
@@ -164,6 +173,40 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
+	// Admissions
+	$wp_customize->add_setting(
+		'apply_undergraduate_url',
+		array(
+			'default' => get_theme_mod_default( 'apply_undergraduate_url' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'apply_undergraduate_url',
+		array(
+			'type'        => 'text',
+			'label'       => 'Undergraduate Application URL',
+			'description' => 'URL that points to the undergraduate student application.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'admissions'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'apply_graduate_url',
+		array(
+			'default' => get_theme_mod_default( 'apply_graduate_url' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'apply_graduate_url',
+		array(
+			'type'        => 'text',
+			'label'       => 'Graduate Application URL',
+			'description' => 'URL that points to the graduate student application.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'admissions'
+		)
+	);
 
 	// People
 	if ( post_type_exists( 'person' ) ) {

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Returns markup for a degree's meta information in a stylized box.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Mixed | meta info HTML or void
+ **/
+function get_degree_meta_markup( $post ) {
+	if ( !$post->post_type == 'degree' ) { return; }
+
+	$program_types = wp_get_post_terms( $post->ID, 'program_types' );
+	$program_types = !is_wp_error( $program_types ) && !empty( $program_types ) && class_exists( 'UCF_Degree_Program_Types_Common' ) ? $program_types : false;
+	$depts         = wp_get_post_terms( $post->ID, 'departments' );
+	$depts         = !is_wp_error( $depts ) && !empty( $depts ) && class_exists( 'UCF_Departments_Common' ) ? $depts : false;
+
+	ob_start();
+	if ( $program_types || $depts ):
+?>
+	<div class="card card-faded">
+		<div class="card-block">
+			<dl class="row mb-0">
+				<?php if ( $program_types ): ?>
+				<dt class="col-lg-4">Degree</dt>
+				<dd class="col-lg-8">
+					<ul class="list-unstyled mb-0">
+						<?php foreach ( $program_types as $program_type ): ?>
+						<li><?php echo UCF_Degree_Program_Types_Common::get_name_or_alias( $program_type ); ?></li>
+						<?php endforeach; ?>
+					</ul>
+				</dd>
+				<?php endif; ?>
+
+				<?php if ( $depts ): ?>
+				<dt class="col-lg-4">Department<?php if ( count( $depts ) > 1 ) { ?>s<?php } ?></dt>
+				<dd class="col-lg-8">
+					<ul class="list-unstyled mb-0">
+						<?php foreach ( $depts as $dept ): ?>
+						<li><?php echo UCF_Departments_Common::get_website_link( $dept ); ?></li>
+						<?php endforeach; ?>
+					</ul>
+				</dd>
+				<?php endif; ?>
+			</dl>
+		</div>
+	</div>
+<?php
+	endif;
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns markup for a degree's description from the academic catalog.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Mixed | description HTML or void
+ **/
+function get_degree_desc_markup( $post ) {
+	if ( !$post->post_type == 'degree' ) { return; }
+
+	ob_start();
+	// if (  ):
+?>
+<?php
+	// endif;
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns markup for a degree's call-to-action buttons.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Mixed | CTA HTML or void
+ **/
+function get_degree_cta_btns_markup( $post ) {
+	if ( !$post->post_type == 'degree' ) { return; }
+
+	ob_start();
+?>
+<?php
+	return ob_get_clean();
+}

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -18,12 +18,12 @@ function get_degree_meta_markup( $post ) {
 	ob_start();
 	if ( $program_types || $depts ):
 ?>
-	<div class="card card-faded">
+	<div class="card card-faded mb-3 mb-lg-4">
 		<div class="card-block">
 			<dl class="row mb-0">
 				<?php if ( $program_types ): ?>
-				<dt class="col-lg-4">Degree</dt>
-				<dd class="col-lg-8">
+				<dt class="col-sm-4">Degree</dt>
+				<dd class="col-sm-8">
 					<ul class="list-unstyled mb-0">
 						<?php foreach ( $program_types as $program_type ): ?>
 						<li><?php echo UCF_Degree_Program_Types_Common::get_name_or_alias( $program_type ); ?></li>
@@ -33,8 +33,8 @@ function get_degree_meta_markup( $post ) {
 				<?php endif; ?>
 
 				<?php if ( $depts ): ?>
-				<dt class="col-lg-4">Department<?php if ( count( $depts ) > 1 ) { ?>s<?php } ?></dt>
-				<dd class="col-lg-8">
+				<dt class="col-sm-4">Department<?php if ( count( $depts ) > 1 ) { ?>s<?php } ?></dt>
+				<dd class="col-sm-8">
 					<ul class="list-unstyled mb-0">
 						<?php foreach ( $depts as $dept ): ?>
 						<li><?php echo UCF_Departments_Common::get_website_link( $dept ); ?></li>
@@ -52,6 +52,8 @@ function get_degree_meta_markup( $post ) {
 
 
 /**
+ * TODO - actually return the description
+ *
  * Returns markup for a degree's description from the academic catalog.
  *
  * @author Jo Dickson
@@ -72,6 +74,66 @@ function get_degree_desc_markup( $post ) {
 
 
 /**
+ * TODO - actually determine the program type
+ *
+ * Returns whether or not a given degree is an undergraduate degree.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Boolean
+ **/
+function is_undergraduate_degree( $post ) {
+	if ( !$post->post_type == 'degree' ) { return false; }
+
+	return true;
+}
+
+
+/**
+ * TODO - actually determine the program type
+ *
+ * Returns whether or not a given degree is a graduate degree.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Boolean
+ **/
+function is_graduate_degree( $post ) {
+	if ( !$post->post_type == 'degree' ) { return false; }
+
+	return true;
+}
+
+
+/**
+ * Returns the UCF application URL for a given degree.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Mixed | url string or void
+ **/
+function get_degree_apply_url( $post ) {
+	if ( !$post->post_type == 'degree' ) { return; }
+
+	$apply_url = '';
+
+	// Determine whether degree is undergraduate or graduate.  Note that
+	// some degrees may not have an undergraduate or graduate program type.
+	if ( is_undergraduate_degree( $post ) ) {
+		$apply_url = get_theme_mod_or_default( 'apply_undergraduate_url' );
+	}
+	elseif ( is_graduate_degree( $post ) ) {
+		$apply_url = get_theme_mod_or_default( 'apply_graduate_url' );
+	}
+
+	return $apply_url;
+}
+
+
+/**
  * Returns markup for a degree's call-to-action buttons.
  *
  * @author Jo Dickson
@@ -82,8 +144,18 @@ function get_degree_desc_markup( $post ) {
 function get_degree_cta_btns_markup( $post ) {
 	if ( !$post->post_type == 'degree' ) { return; }
 
+	$apply_url = get_degree_apply_url( $post );
+	$catalog_url = 'http://catalog.ucf.edu'; // TODO fetch the actual catalog url
+
 	ob_start();
 ?>
+	<?php if ( $apply_url ): ?>
+	<a class="btn btn-block btn-primary" href="<?php echo $apply_url; ?>">Apply Now</a>
+	<?php endif; ?>
+
+	<?php if ( $catalog_url ): ?>
+	<a class="btn btn-block btn-primary" href="<?php echo $catalog_url; ?>">Download Catalog PDF</a>
+	<?php endif; ?>
 <?php
 	return ob_get_clean();
 }

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -52,7 +52,7 @@ function get_degree_meta_markup( $post ) {
 
 
 /**
- * TODO - actually return the description
+ * TODO - actually return a description from search service data
  *
  * Returns markup for a degree's description from the academic catalog.
  * If a post excerpt is available, it will be returned instead.
@@ -65,7 +65,7 @@ function get_degree_meta_markup( $post ) {
 function get_degree_desc_markup( $post ) {
 	if ( !$post->post_type == 'degree' ) { return; }
 
-	$desc = has_excerpt( $post->ID ) ? get_the_excerpt( $post->ID ) : get_post_meta( 'degree_description', $post->ID, true ); // TODO field name
+	$desc = has_excerpt( $post->ID ) ? get_the_excerpt( $post->ID ) : get_post_meta( 'degree_description', $post->ID, true ); // TODO field name for imported degree data?
 
 	ob_start();
 	if ( $desc ):
@@ -140,6 +140,24 @@ function get_degree_apply_url( $post ) {
 
 
 /**
+ * TODO
+ * Returns the catalog URL for a given degree.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ * @param $post object | Degree post object
+ * @return Mixed | url string or void
+ **/
+function get_degree_catalog_url( $post ) {
+	if ( !$post->post_type == 'degree' ) { return; }
+
+	$apply_url = 'http://catalog.ucf.edu';  // TODO
+
+	return $apply_url;
+}
+
+
+/**
  * Returns markup for a degree's call-to-action buttons.
  *
  * @author Jo Dickson
@@ -151,7 +169,7 @@ function get_degree_cta_btns_markup( $post ) {
 	if ( !$post->post_type == 'degree' ) { return; }
 
 	$apply_url = get_degree_apply_url( $post );
-	$catalog_url = 'http://catalog.ucf.edu'; // TODO fetch the actual catalog url
+	$catalog_url = get_degree_catalog_url( $post );
 
 	ob_start();
 ?>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -55,6 +55,7 @@ function get_degree_meta_markup( $post ) {
  * TODO - actually return the description
  *
  * Returns markup for a degree's description from the academic catalog.
+ * If a post excerpt is available, it will be returned instead.
  *
  * @author Jo Dickson
  * @since 1.0.0
@@ -64,11 +65,16 @@ function get_degree_meta_markup( $post ) {
 function get_degree_desc_markup( $post ) {
 	if ( !$post->post_type == 'degree' ) { return; }
 
+	$desc = has_excerpt( $post->ID ) ? get_the_excerpt( $post->ID ) : get_post_meta( 'degree_description', $post->ID, true ); // TODO field name
+
 	ob_start();
-	// if (  ):
+	if ( $desc ):
 ?>
+	<div class="lead font-slab-serif">
+		<?php echo apply_filters( 'the_content', $desc ); ?>
+	</div>
 <?php
-	// endif;
+	endif;
 	return ob_get_clean();
 }
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -68,9 +68,9 @@ function get_header_images( $post ) {
 		'header_image_xs' => ''
 	);
 
-	if ( $post->post_type == 'person' ) {
-		$retval['header_image']    = get_theme_mod( 'person_header_image' );
-		$retval['header_image_xs'] = get_theme_mod( 'person_header_image_xs' );
+	if ( $post->post_type == 'person' || $post->post_type == 'degree' ) {
+		$retval['header_image']    = get_theme_mod( $post->post_type . '_header_image' );
+		$retval['header_image_xs'] = get_theme_mod( $post->post_type . '_header_image_xs' );
 	}
 
 	if ( $post_header_image = get_field( 'page_header_image', $post->ID ) ) {
@@ -152,7 +152,7 @@ function get_header_subtitle( $post ) {
 function get_header_height( $post ) {
 	$retval = 'header-media-default';
 
-	if ( $post->post_type == 'person' ) {
+	if ( $post->post_type == 'person' || $post->post_type == 'degree' ) {
 		$retval = 'header-media-short';
 	}
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -232,7 +232,7 @@ function get_header_media_markup( $post, $videos=null, $images=null ) {
 						$bg_image_srcs = get_media_background_picture_srcs( null, $images['header_image'], 'bg-img' );
 						$bg_image_src_xs = get_media_background_picture_srcs( $images['header_image_xs'], null, 'header-img' );
 
-						if ( $bg_image_src_xs['xs'] ) {
+						if ( isset( $bg_image_src_xs['xs'] ) ) {
 							$bg_image_srcs['xs'] = $bg_image_src_xs['xs'];
 						}
 						break;
@@ -240,7 +240,7 @@ function get_header_media_markup( $post, $videos=null, $images=null ) {
 						$bg_image_srcs = get_media_background_picture_srcs( null, $images['header_image'], 'header-img-short' );
 						$bg_image_src_xs = get_media_background_picture_srcs( $images['header_image_xs'], null, 'header-img' );
 
-						if ( $bg_image_src_xs['xs'] ) {
+						if ( isset( $bg_image_src_xs['xs'] ) ) {
 							$bg_image_srcs['xs'] = $bg_image_src_xs['xs'];
 						}
 						break;

--- a/includes/person-functions.php
+++ b/includes/person-functions.php
@@ -89,7 +89,7 @@ function get_person_contact_btns_markup( $post ) {
 
 
 /**
- * Display's a person's department(s) in a condensed table-like format.
+ * Displays a person's department(s) in a condensed table-like format.
  * For use on single-person.php
  *
  * @author Jo Dickson
@@ -100,23 +100,20 @@ function get_person_contact_btns_markup( $post ) {
 function get_person_dept_markup( $post ) {
 	if ( $post->post_type !== 'person' ) { return; }
 
+	$depts = wp_get_post_terms( $post->ID, 'departments' );
+	$depts = !is_wp_error( $depts ) && !empty( $depts ) && class_exists( 'UCF_Departments_Common' ) ? $depts : false;
+
 	ob_start();
-	if ( taxonomy_exists( 'departments' ) && $departments = wp_get_post_terms( $post->ID, 'departments' ) ) :
+	if ( $depts ) :
 ?>
 	<div class="row">
 		<div class="col-xl-4 col-md-12 col-sm-4 person-label">
-			Department<?php if ( count( $departments ) > 1 ) { echo 's'; } ?>
+			Department<?php if ( count( $depts ) > 1 ) { echo 's'; } ?>
 		</div>
 		<div class="col-xl-8 col-md-12 col-sm-8 person-attr">
 			<ul class="list-unstyled mb-0">
-				<?php foreach ( $departments as $dept ): ?>
-				<li>
-					<?php if ( $website = get_term_meta( $dept->term_id, 'departments_website', true ) ): ?>
-					<a href="<?php echo $website; ?>"><?php echo $dept->name; ?></a>
-					<?php else: ?>
-					<?php echo $dept->name; ?>
-					<?php endif; ?>
-				</li>
+				<?php foreach ( $depts as $dept ): ?>
+				<li><?php echo UCF_Departments_Common::get_website_link( $dept ); ?></li>
 				<?php endforeach; ?>
 			</ul>
 		</div>

--- a/includes/person-functions.php
+++ b/includes/person-functions.php
@@ -63,8 +63,8 @@ function get_person_contact_btns_markup( $post ) {
 	if ( $post->post_type !== 'person' ) { return; }
 
 	$email      = get_field( 'person_email', $post->ID );
-	$has_phones = have_rows( 'person_phones', $post->ID );
-	$phones     = get_field( 'person_phones', $post->ID );
+	$has_phones = have_rows( 'person_phone_numbers', $post->ID );
+	$phones     = get_field( 'person_phone_numbers', $post->ID );
 
 	ob_start();
 
@@ -211,7 +211,7 @@ function get_person_phones_markup( $post ) {
 	if ( $post->post_type !== 'person' ) { return; }
 
 	ob_start();
-	if ( have_rows( 'person_phones', $post->ID ) ):
+	if ( have_rows( 'person_phone_numbers', $post->ID ) ):
 ?>
 	<div class="row">
 		<div class="col-xl-4 col-md-12 col-sm-4 person-label">
@@ -220,7 +220,7 @@ function get_person_phones_markup( $post ) {
 		<div class="col-xl-8 col-md-12 col-sm-8 person-attr">
 			<ul class="list-unstyled mb-0">
 			<?php
-			while ( have_rows( 'person_phones', $post->ID ) ): the_row();
+			while ( have_rows( 'person_phone_numbers', $post->ID ) ): the_row();
 				$phone = get_sub_field( 'number' );
 				if ( $phone ):
 			?>
@@ -341,12 +341,12 @@ function get_person_videos_markup( $post ) {
 
 	ob_start();
 
-	if ( have_rows( 'person_media', $post->ID ) ):
+	if ( have_rows( 'person_medias', $post->ID ) ):
 ?>
 	<h2 class="person-subheading mt-5">Videos and Media</h2>
 	<div class="row">
 		<?php
-		while ( have_rows( 'person_media', $post->ID ) ): the_row();
+		while ( have_rows( 'person_medias', $post->ID ) ): the_row();
 			$video_title  = get_sub_field( 'title' );
 			$video_embed  = get_sub_field( 'link' );
 			$video_source = get_sub_field( 'source' );

--- a/page.php
+++ b/page.php
@@ -1,9 +1,1 @@
-<?php get_header(); the_post(); ?>
-
-<div class="container mb-5">
-	<article class="<?php echo $post->post_status; ?> post-list-item">
-		<?php the_content(); ?>
-	</article>
-</div>
-
-<?php get_footer(); ?>
+<?php require_once( 'template-basic.php' ); ?>

--- a/readme.markdown
+++ b/readme.markdown
@@ -13,11 +13,13 @@ This theme is developed and tested against WordPress 4.7.3+ and PHP 5.3.x+.
 ### Recommended Plugins
 * Athena Shortcodes
 * Page Links To
+* UCF Degree Custom Post Type
 * UCF Departments Taxonomy
+* UCF Employee Types Taxonomy
 * UCF Events
 * UCF News
 * UCF Page Assets
-* UCF Person Custom Post Type
+* UCF People Custom Post Type
 * UCF Social
 * UCF Spotlight
 * Varnish Dependency Purger

--- a/single-degree.php
+++ b/single-degree.php
@@ -1,8 +1,17 @@
 <?php get_header(); the_post(); ?>
 
-<div class="container mb-5">
+<div class="container mb-5 mt-3 mt-md-5">
 	<article class="<?php echo $post->post_status; ?> post-list-item">
-		<?php the_content(); ?>
+		<div class="row">
+			<div class="col-md-8">
+				<?php echo get_degree_meta_markup( $post ); ?>
+				<?php echo get_degree_desc_markup( $post ); ?>
+				<?php the_content(); ?>
+			</div>
+			<div class="col-md-4">
+				<?php echo get_degree_cta_btns_markup( $post ); ?>
+			</div>
+		</div>
 	</article>
 </div>
 

--- a/single-degree.php
+++ b/single-degree.php
@@ -1,18 +1,40 @@
-<?php get_header(); the_post(); ?>
+<?php
+get_header(); the_post();
 
-<div class="container mb-5 mt-3 mt-lg-5">
+$cta_btns = get_degree_cta_btns_markup( $post );
+$sidebar_content = get_field( 'degree_sidebar_content' );
+?>
+
+<div class="container mb-5 mt-3 mt-md-4 mt-lg-5">
 	<article class="<?php echo $post->post_status; ?> post-list-item">
 		<div class="row">
 			<div class="col-lg-8">
 				<?php echo get_degree_meta_markup( $post ); ?>
-			</div>
-			<div class="col-lg-4 mb-3 mb-lg-4">
-				<?php echo get_degree_cta_btns_markup( $post ); ?>
-			</div>
-			<div class="col-lg-8 mt-3">
+
+				<?php if ( $cta_btns ): ?>
+				<div class="hidden-lg-up mb-4">
+					<?php echo $cta_btns; ?>
+				</div>
+				<?php endif; ?>
+
 				<?php echo get_degree_desc_markup( $post ); ?>
 				<?php the_content(); ?>
+
+				<?php if ( $sidebar_content ): ?>
+				<div class="hidden-lg-up mt-5">
+					<?php echo $sidebar_content; ?>
+				</div>
+				<?php endif; ?>
 			</div>
+
+			<?php if ( $cta_btns || $sidebar_content ): ?>
+			<div class="col-lg-4 hidden-md-down">
+				<?php echo $cta_btns; ?>
+				<div class="my-5">
+					<?php echo $sidebar_content; ?>
+				</div>
+			</div>
+			<?php endif; ?>
 		</div>
 	</article>
 </div>

--- a/single-degree.php
+++ b/single-degree.php
@@ -9,7 +9,7 @@
 			<div class="col-lg-4 mb-3 mb-lg-4">
 				<?php echo get_degree_cta_btns_markup( $post ); ?>
 			</div>
-			<div class="col-lg-8">
+			<div class="col-lg-8 mt-3">
 				<?php echo get_degree_desc_markup( $post ); ?>
 				<?php the_content(); ?>
 			</div>

--- a/single-degree.php
+++ b/single-degree.php
@@ -1,15 +1,17 @@
 <?php get_header(); the_post(); ?>
 
-<div class="container mb-5 mt-3 mt-md-5">
+<div class="container mb-5 mt-3 mt-lg-5">
 	<article class="<?php echo $post->post_status; ?> post-list-item">
 		<div class="row">
-			<div class="col-md-8">
+			<div class="col-lg-8">
 				<?php echo get_degree_meta_markup( $post ); ?>
+			</div>
+			<div class="col-lg-4 mb-3 mb-lg-4">
+				<?php echo get_degree_cta_btns_markup( $post ); ?>
+			</div>
+			<div class="col-lg-8">
 				<?php echo get_degree_desc_markup( $post ); ?>
 				<?php the_content(); ?>
-			</div>
-			<div class="col-md-4">
-				<?php echo get_degree_cta_btns_markup( $post ); ?>
 			</div>
 		</div>
 	</article>

--- a/single-degree.php
+++ b/single-degree.php
@@ -1,0 +1,9 @@
+<?php get_header(); the_post(); ?>
+
+<div class="container mb-5">
+	<article class="<?php echo $post->post_status; ?> post-list-item">
+		<?php the_content(); ?>
+	</article>
+</div>
+
+<?php get_footer(); ?>

--- a/single-person.php
+++ b/single-person.php
@@ -43,7 +43,6 @@
 						echo '<p>No biography available.</p>';
 					}
 					?>
-
 					<?php if ( $cv_url = get_field( 'person_cv' ) ): ?>
 					<p>
 						<a class="btn btn-primary mt-3" href="<?php echo $cv_url; ?>">Download CV</a>

--- a/single.php
+++ b/single.php
@@ -1,9 +1,1 @@
-<?php get_header(); the_post(); ?>
-
-<div class="container mb-5">
-	<article class="<?php echo $post->post_status; ?> post-list-item">
-		<?php the_content(); ?>
-	</article>
-</div>
-
-<?php get_footer(); ?>
+<?php require_once( 'template-basic.php' ); ?>

--- a/single.php
+++ b/single.php
@@ -1,0 +1,9 @@
+<?php get_header(); the_post(); ?>
+
+<div class="container mb-5">
+	<article class="<?php echo $post->post_status; ?> post-list-item">
+		<?php the_content(); ?>
+	</article>
+</div>
+
+<?php get_footer(); ?>

--- a/template-basic.php
+++ b/template-basic.php
@@ -6,7 +6,7 @@
 ?>
 <?php get_header(); the_post(); ?>
 
-<div class="container mb-5">
+<div class="container mb-5 mt-3 mt-lg-5">
 	<article class="<?php echo $post->post_status; ?> post-list-item">
 		<?php the_content(); ?>
 	</article>

--- a/template-basic.php
+++ b/template-basic.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template Name: Basic
+ * Template Post Type: degree
+ */
+?>
+<?php get_header(); the_post(); ?>
+
+<div class="container mb-5">
+	<article class="<?php echo $post->post_status; ?> post-list-item">
+		<?php the_content(); ?>
+	</article>
+</div>
+
+<?php get_footer(); ?>

--- a/template-fullscreen.php
+++ b/template-fullscreen.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Template Name: Full Width Page
+ * Template Name: Full Width
+ * Template Post Type: page, degree
  */
 ?>
 <?php get_header(); the_post(); ?>


### PR DESCRIPTION
Degrees:
- Added an initial single degree template.  TODOs are left in place intentionally for data we don't have imports in place for yet (they depend on a genericized data importer for search service data).
- Added the full-width template as a template option for degrees, and moved page.php's and single.php's markup to a new template, template-basic.php.  The new "basic" template is also available for degrees.

Field updates/other stuff:
- Updated a few person field names to avoid overriding existing post metadata upon migration.
- Updated person department links to use `UCF_Departments_Common::get_website_link()`