### PR TITLE
Readme updates

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # Colleges Theme
 
-A responsive WordPress theme for UCF's college websites, built off of the [Athena Framework](https://github.com/UCF/Athena-Framework).
+A responsive WordPress theme for UCF's college websites, built off of the [Athena Framework](https://ucf.github.io/Athena-Framework/).
 
 
 ## Installation Requirements
@@ -8,29 +8,31 @@ A responsive WordPress theme for UCF's college websites, built off of the [Athen
 This theme is developed and tested against WordPress 4.7.3+ and PHP 5.3.x+.
 
 ### Required Plugins
-* Advanced Custom Fields PRO
+These plugins *must* be activated for the theme to function properly.
+* [Advanced Custom Fields PRO](https://www.advancedcustomfields.com/pro/)
 
-### Recommended Plugins
-* Athena Shortcodes
-* Automatic Sections Menu Shortcode
-* Gravity Forms
-* Page Links To
-* UCF Degree Custom Post Type
-* UCF Departments Taxonomy
-* UCF Employee Types Taxonomy
-* UCF Events
-* UCF News
-* UCF Page Assets
-* UCF Post List Shortcode (2.0.0+)
-* UCF People Custom Post Type
-* UCF Section
-* UCF Social
-* UCF Spotlight
-* Varnish Dependency Purger or UCF WordPress Varnish as a Service
-* WP Allowed Hosts
-* WP Mail SMTP
-* WP Shortcode Interface
-* Yoast SEO
+### Supported Plugins
+The plugins listed below are extended upon in this theme--this may include custom layouts for feeds, style modifications, etc. These plugins are not technically required on sites running this theme, and shouldn't be activated on sites that don't require their features. A plugin does not have to be listed here to be compatible with this theme.
+* [Athena Shortcodes](https://github.com/UCF/Athena-Shortcodes-Plugin)
+* [Gravity Forms](https://www.gravityforms.com/)
+* [Page Links To](https://wordpress.org/plugins/page-links-to/)
+* [Sections Menus Shortcode](https://github.com/UCF/Section-Menus-Shortcode)
+* [UCF Degree Custom Post Type](https://github.com/UCF/UCF-Degree-CPT-Plugin)
+* [UCF Departments Taxonomy](https://github.com/UCF/UCF-Departments-Tax-Plugin)
+* [UCF Employee Type Taxonomy](https://github.com/UCF/UCF-Employee-Type-Tax-Plugin)
+* [UCF Events](https://github.com/UCF/UCF-Events-Plugin)
+* [UCF News](https://github.com/UCF/UCF-News-Plugin)
+* [UCF Page Assets](https://github.com/UCF/UCF-Page-Assets-Plugin)
+* [UCF Post List Shortcode (2.0.0+)](https://github.com/UCF/UCF-Post-List-Shortcode)
+* [UCF People Custom Post Type](https://github.com/UCF/UCF-People-CPT)
+* [UCF Section](https://github.com/UCF/UCF-Section-Plugin)
+* [UCF Social](https://github.com/UCF/UCF-Social-Plugin)
+* [UCF Spotlights](https://github.com/UCF/UCF-Spotlights-Plugin)
+* [Varnish Dependency Purger](https://github.com/UCF/VarnishDependencyPurge) or [UCF WordPress Varnish as a Service](https://github.com/UCF/UCF-WordPress-Varnish-as-a-Service)
+* [WP Allowed Hosts](https://github.com/UCF/WP-Allowed-Hosts)
+* [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)
+* [WP Shortcode Interface](https://github.com/UCF/WP-Shortcode-Interface)
+* [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/)
 
 
 ## Configuration

--- a/readme.markdown
+++ b/readme.markdown
@@ -14,9 +14,9 @@ These plugins *must* be activated for the theme to function properly.
 ### Supported Plugins
 The plugins listed below are extended upon in this theme--this may include custom layouts for feeds, style modifications, etc. These plugins are not technically required on sites running this theme, and shouldn't be activated on sites that don't require their features. A plugin does not have to be listed here to be compatible with this theme.
 * [Athena Shortcodes](https://github.com/UCF/Athena-Shortcodes-Plugin)
+* [Automatic Sections Menus Shortcode](https://github.com/UCF/Section-Menus-Shortcode)
 * [Gravity Forms](https://www.gravityforms.com/)
 * [Page Links To](https://wordpress.org/plugins/page-links-to/)
-* [Sections Menus Shortcode](https://github.com/UCF/Section-Menus-Shortcode)
 * [UCF Degree Custom Post Type](https://github.com/UCF/UCF-Degree-CPT-Plugin)
 * [UCF Departments Taxonomy](https://github.com/UCF/UCF-Departments-Tax-Plugin)
 * [UCF Employee Type Taxonomy](https://github.com/UCF/UCF-Employee-Type-Tax-Plugin)
@@ -28,7 +28,6 @@ The plugins listed below are extended upon in this theme--this may include custo
 * [UCF Section](https://github.com/UCF/UCF-Section-Plugin)
 * [UCF Social](https://github.com/UCF/UCF-Social-Plugin)
 * [UCF Spotlights](https://github.com/UCF/UCF-Spotlights-Plugin)
-* [Varnish Dependency Purger](https://github.com/UCF/VarnishDependencyPurge) or [UCF WordPress Varnish as a Service](https://github.com/UCF/UCF-WordPress-Varnish-as-a-Service)
 * [WP Allowed Hosts](https://github.com/UCF/WP-Allowed-Hosts)
 * [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)
 * [WP Shortcode Interface](https://github.com/UCF/WP-Shortcode-Interface)


### PR DESCRIPTION
- Updated readme to include an explanation of the difference between 'Required Plugins' and 'Supported Plugins' (matches what we use for [UCF WordPress Theme](https://github.com/UCF/UCF-WordPress-Theme/blob/master/readme.markdown))
- Linked plugins to corresponding repos or informative websites
- Updated the Athena link to lead to the Overview page instead of the repo, I feel as if that page gives a bit more insight into what Athena is/does and is more enticing than the repo readme