### PR TITLE
change is_home to is_front_page

### DIFF
--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -25,7 +25,7 @@ function get_nav_markup() {
 ?>
 	<nav class="navbar navbar-toggleable-md navbar-inverse site-navbar" role="navigation">
 		<div class="container">
-			<?php if ( is_home() ): ?>
+			<?php if ( is_front_page() ): ?>
 			<h1 class="navbar-brand mb-0">
 				<?php echo get_sitename_formatted(); ?>
 			</h1>


### PR DESCRIPTION
WordPress uses is_home for the blog archive page. This is not always the root page, whereas the front_page is the root page. Therefore, the site name should be linked on the home page for sites where it isn't the front page.