### PR TITLE
Removed the cloud typography settings from the customizer

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -97,13 +97,6 @@ function define_customizer_sections( $wp_customize ) {
 	);
 
 	$wp_customize->add_section(
-		COLLEGES_THEME_CUSTOMIZER_PREFIX . 'webfonts',
-		array(
-			'title' => 'Web Fonts'
-		)
-	);
-
-	$wp_customize->add_section(
 		COLLEGES_THEME_CUSTOMIZER_PREFIX . 'admissions',
 		array(
 			'title' => 'UCF Admissions'
@@ -209,24 +202,6 @@ function define_customizer_fields( $wp_customize ) {
 			'label'       => 'Google Analytics Account',
 			'description' => 'Example: <em>UA-9876543-21</em>.<br>Leave blank for development, or if you\'ve provided a Google Tag Manager Container ID and include Google Analytics via Google Tag Manager.',
 			'section'     => COLLEGES_THEME_CUSTOMIZER_PREFIX . 'analytics'
-		)
-	);
-
-	// Web Fonts
-	$wp_customize->add_setting(
-		'cloud_typography_key'
-	);
-
-	$wp_customize->add_control(
-		'cloud_typography_key',
-		array(
-			'type'        => 'text',
-			'label'       => 'Cloud.Typography CSS Key URL',
-			'description' => 'The CSS Key provided by Cloud.Typography for this project.  <strong>Only include the value in the "href" portion of the link
-								tag provided; e.g. "//cloud.typography.com/000000/000000/css/fonts.css".</strong><br><br>NOTE: Make sure the Cloud.Typography
-								project has been configured to deliver fonts to this site\'s domain.<br>
-								See the <a target="_blank" href="http://www.typography.com/cloud/user-guide/managing-domains">Cloud.Typography docs on managing domains</a> for more info.',
-			'section'     => COLLEGES_THEME_CUSTOMIZER_PREFIX . 'webfonts'
 		)
 	);
 

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -12,12 +12,6 @@ function enqueue_frontend_assets() {
 	$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
 	$style_deps    = array();
 
-	// Register Cloud.Typography CSS Key
-	if ( $fontkey = get_theme_mod( 'cloud_typography_key' ) ) {
-		wp_enqueue_style( 'webfont', $fontkey, null, null );
-		$style_deps[] = 'webfont';
-	}
-
 	// Register main theme stylesheet
 	wp_enqueue_style( 'style', COLLEGES_THEME_CSS_URL . '/style.min.css', $style_deps, $theme_version );
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's Colleges Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Colleges-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes the cloud typography setting from the theme customizer as well as the logic that uses the setting to enqueue the CSS file.

**Motivation and Context**
We don't want users to be confused into thinking the cloud fonts will still work with this theme out of the box.

**How Has This Been Tested?**
Changes have been tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
