### PR TITLE
UCF Header Fix

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -71,6 +71,29 @@ add_filter( 'emoji_svg_url', '__return_false' );
 
 
 /**
+ * Replaces the ucf-header bar ID with the correct
+ * ID needed for the script to work correctly.
+ *
+ * @author Jim Barnes
+ * @since v1.5.0
+ *
+ * @param string $tag The script tag being filtered
+ * @param string $handle The handle of the header script
+ * @param string $src The source of the script
+ */
+function ucfhb_script_handle( $tag, $handle, $src ) {
+	if ( false !== strpos( $src, 'universityheader.ucf.edu' ) ) {
+		$tag = str_replace( "{$handle}-js", 'ucfhb-script', $tag );
+	}
+
+	return $tag;
+}
+
+if ( version_compare( $wp_version, '6.3.0', '>=' ) ) {
+	add_filter( 'script_loader_tag', 'ucfhb_script_handle', 10, 3 );
+}
+
+/**
  * Adds ID attribute to UCF Header script.
  **/
 function add_id_to_ucfhb( $url ) {
@@ -84,7 +107,9 @@ function add_id_to_ucfhb( $url ) {
     return $url;
 }
 
-add_filter( 'clean_url', 'add_id_to_ucfhb', 10, 1 );
+if ( version_compare( $wp_version, '6.3.0', '<' ) ) {
+	add_filter( 'clean_url', 'add_id_to_ucfhb', 10, 1 );
+}
 
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to UCF's Colleges Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Colleges-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a backwards compatible fix to the UCF Header bar enqueuing logic.

**Motivation and Context**
For WordPress 6.3+, the old hack we used to insert an ID into the university header script tag no longer works. WordPress has started automatically adding an ID based on the scripts handle. I have created a new function that will correctly insert the ID for 6.3.0 and higher, and left the function for 6.3.0 and lower, using a quick version check to add the appropriate filter.

**How Has This Been Tested?**
Changes have been tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
